### PR TITLE
Fix #28

### DIFF
--- a/R/fish_shapes.R
+++ b/R/fish_shapes.R
@@ -74,10 +74,13 @@ fishapes <- function(){
   httr::stop_for_status(req)
   text <- httr::content(req, "text")
 
-  text_sub <- stringr::str_split(text, "\\s+")[[1]] %>%
-    stringr::str_subset(".png")  %>%
-    stringr::str_subset("title") %>%
-    stringr::str_sub(start = 8, end = -6)
+  # text_sub <- stringr::str_split(text, "\\s+")[[1]] %>%
+  #   stringr::str_subset(".png")  %>%
+  #   stringr::str_subset("title") %>%
+  #   stringr::str_sub(start = 8, end = -6)
+
+  text_sub <- stringr::str_extract_all(text,
+                                       '(?<=,\\{\"name\":\").+?(?=.png\")')[[1]]
 
   df <- data.frame(text_sub = text_sub) %>%
     tidyr::separate(text_sub, into = c("family", "option"), sep = "_") %>%


### PR DESCRIPTION
Hi @nschiett, `fishapes()` is currently not working as reported in #28, so it is not possible to add silhouettes to plots. I noticed that the issue lies in extracting fish names from the html file.

``` r
library(fishualize)
fishapes()
#> Warning: Expected 2 pieces. Additional pieces discarded in 1 rows [1].
#>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               family
#> 1 rget="react-app.embeddedData">{"payload":{"allShortcutsEnabled":false,"path":"shapes","repo":{"id":249653609,"defaultBranch":"master","name":"fishape","ownerLogin":"simonjbrandl","currentUserCanPush":false,"isFork":false,"isEmpty":false,"createdAt":"2020-03-24T08:34:03.000Z","ownerAvatar":"https://avatars.githubusercontent.com/u/9363612?v=4","public":true,"private":false,"isOrgOwned":false},"currentUser":null,"refInfo":{"name":"master","listCacheKey":"v0:1585047889.0","canEdit":false,"refType":"branch","currentOid":"f339212f3931804357a5796b4b5ab0631c96583a"},"tree":{"items":[{"name":".DS
#>                      option
#> 1 Store","path":"shapes/_DS

library(ggplot2)
ggplot(diamonds) +
  geom_bar(aes(cut, fill = cut)) +
  scale_fill_fish_d(option = "Naso_lituratus") +
  add_fishape(family = "Acanthuridae",
              option = "Naso_unicornis",
              xmin = 1, xmax = 3, ymin = 15000, ymax = 20000,
              fill = fish(option = "Naso_lituratus", n = 4)[2],
              alpha = 0.8) +
  theme_bw()
#> Warning: Expected 2 pieces. Additional pieces discarded in 1 rows [1].
#> Error in add_fishape(family = "Acanthuridae", option = "Naso_unicornis", : This family is not available or misspelled
```

This PR fixes this issue and gets `fishapes()` and `add_fishape()` back to work.

``` r
#devtools::install_github("mattiaghilardi/fishualize", ref = "fix-fishapes")
library(fishualize)
head(fishapes())
#>         family                option
#> 1 Acanthuridae Acanthurus_nigricauda
#> 2 Acanthuridae Ctenochaetus_striatus
#> 3 Acanthuridae        Naso_lituratus
#> 4 Acanthuridae        Naso_unicornis
#> 5 Acanthuridae      Zebrasoma_scopas
#> 6 Acanthuridae     Zebrasoma_velifer

library(ggplot2)
ggplot(diamonds) +
  geom_bar(aes(cut, fill = cut)) +
  scale_fill_fish_d(option = "Naso_lituratus") +
  add_fishape(family = "Acanthuridae",
              option = "Naso_unicornis",
              xmin = 1, xmax = 3, ymin = 15000, ymax = 20000,
              fill = fish(option = "Naso_lituratus", n = 4)[2],
              alpha = 0.8) +
  theme_bw()
```

![](https://i.imgur.com/hq9Z5xc.png)

<sup>Created on 2024-03-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>